### PR TITLE
feat: Enable Job Application Deletion  

### DIFF
--- a/backend/src/features/jobApplications/jobApplications.handlers.ts
+++ b/backend/src/features/jobApplications/jobApplications.handlers.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
-import { createJobApplication, getJobApplications } from './jobApplications.service';
+import {
+  createJobApplication,
+  getJobApplications,
+  deleteJobApplication,
+} from './jobApplications.service';
 
 export async function handleGetJobApplications(req: Request, res: Response) {
   try {
@@ -7,7 +11,7 @@ export async function handleGetJobApplications(req: Request, res: Response) {
     res.status(201).json(jobApplications);
   } catch (error) {
     console.error('handler error: ', error);
-    res.status(500).json({ error: 'Something went wrong' })
+    res.status(500).json({ error: 'Something went wrong' });
   }
 }
 
@@ -17,6 +21,18 @@ export async function handleCreateJobApplication(req: Request, res: Response) {
   try {
     const newJobApplication = await createJobApplication(newJobApplicationInfo);
     res.status(201).json(newJobApplication);
+  } catch (error) {
+    console.error('controller error: ', error);
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+}
+
+export async function handleDeleteJobApplication(req: Request, res: Response) {
+  const jobApplicationId = req.body.jobApplicationId;
+
+  try {
+    const updatedJobApplications = await deleteJobApplication(jobApplicationId);
+    res.status(201).json(updatedJobApplications);
   } catch (error) {
     console.error('controller error: ', error);
     res.status(500).json({ error: 'Something went wrong' });

--- a/backend/src/features/jobApplications/jobApplications.routes.ts
+++ b/backend/src/features/jobApplications/jobApplications.routes.ts
@@ -1,9 +1,14 @@
 import express from 'express';
-import { handleCreateJobApplication, handleGetJobApplications } from './jobApplications.handlers';
+import {
+  handleCreateJobApplication,
+  handleGetJobApplications,
+  handleDeleteJobApplication,
+} from './jobApplications.handlers';
 
 const router = express.Router();
 
-router.get('/', handleGetJobApplications)
+router.get('/', handleGetJobApplications);
 router.post('/new', handleCreateJobApplication);
+router.delete(`/:id`, handleDeleteJobApplication);
 
 export default router;

--- a/backend/src/features/jobApplications/jobApplications.service.test.ts
+++ b/backend/src/features/jobApplications/jobApplications.service.test.ts
@@ -1,5 +1,9 @@
 import { prismaMock } from '@/__mocks__/prismaMock';
-import { createJobApplication } from './jobApplications.service';
+import {
+  createJobApplication,
+  deleteJobApplication,
+} from './jobApplications.service';
+import { JobApplication } from '@/src/types/jobApplication';
 
 jest.mock('@/src/config/prisma/prismaClient', () => prismaMock);
 
@@ -15,5 +19,37 @@ describe('createJobApplication', () => {
     expect(prismaMock.jobApplication.create).toHaveBeenCalledWith({
       data: { companyName: 'Test Corp' },
     });
+  });
+});
+
+describe('deleteJobApplication', () => {
+  it('should delete a job application', async () => {
+    const mockJobApplicationDelete = jest.spyOn(
+      prismaMock.jobApplication,
+      'delete'
+    );
+
+    await deleteJobApplication(1);
+
+    expect(mockJobApplicationDelete.mock.calls.length).toBe(1);
+  });
+
+  it('should return an array of job applications', async () => {
+    const mockJobApplications: JobApplication[] = [
+      { id: 1, companyName: 'Test Corp' },
+      { id: 2, companyName: 'Test Corp' },
+      { id: 3, companyName: 'Test Corp' },
+      { id: 4, companyName: 'Test Corp' },
+    ];
+
+    prismaMock.jobApplication.delete.mockResolvedValue({
+      id: 5,
+      companyName: 'Test Corp',
+    });
+    prismaMock.jobApplication.findMany.mockResolvedValue(mockJobApplications);
+
+    const result = await deleteJobApplication(1);
+
+    expect(result).toBe(mockJobApplications);
   });
 });

--- a/backend/src/features/jobApplications/jobApplications.service.ts
+++ b/backend/src/features/jobApplications/jobApplications.service.ts
@@ -19,3 +19,16 @@ export const createJobApplication = async ({
 
   return job;
 };
+
+export const deleteJobApplication = async (postId: number) => {
+  await prisma.jobApplication.delete({
+    where: {
+      id: postId,
+    },
+  });
+
+  const updatedJobApplications: JobApplication[] =
+    await prisma.jobApplication.findMany();
+
+  return updatedJobApplications;
+};

--- a/backend/src/types/jobApplication.ts
+++ b/backend/src/types/jobApplication.ts
@@ -3,5 +3,5 @@ export type NewJobApplication = {
 };
 
 export type JobApplication = NewJobApplication & {
-  companyName: string;
+  id: number;
 };

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -27,7 +27,7 @@ const DashboardPage: FC = () => {
   async function handleDeleteJobApplication(postId: number) {
     const result = await deleteJobApplication(postId);
 
-    console.log(result);
+    setJobApplications(result)
   }
 
   useEffect(() => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import JobApplicationForm from '@/features/dashboard/job-applications/components
 import JobApplicationListTable from '@/features/dashboard/job-applications/components/JobApplicationListTable';
 import { JobApplication } from 'types/jobApplication';
 import { getJobApplications } from '@/features/dashboard/job-applications/api/get-job-applications';
+import { deleteJobApplication } from '@/features/dashboard/job-applications/api/delete-job-application';
 
 const DashboardPage: FC = () => {
   const { session } = useAuth();
@@ -21,6 +22,12 @@ const DashboardPage: FC = () => {
     const result = await getJobApplications();
 
     setJobApplications(result)
+  }
+
+  async function handleDeleteJobApplication(postId: number) {
+    const result = await deleteJobApplication(postId);
+
+    console.log(result);
   }
 
   useEffect(() => {
@@ -45,7 +52,7 @@ const DashboardPage: FC = () => {
         Welcome to your dashboard {userName}
       </h1>
 
-      <JobApplicationListTable jobApplications={jobApplications} />
+      <JobApplicationListTable jobApplications={jobApplications} handleDeleteJobApplication={handleDeleteJobApplication} />
 
       <JobApplicationForm
         handleFormChange={handleFormChange}

--- a/frontend/src/components/ui/Buttons/Button.tsx
+++ b/frontend/src/components/ui/Buttons/Button.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+
+interface ButtonProps {
+  onClick: () => void;
+  content: string;
+}
+
+const Button: FC<ButtonProps> = ({onClick, content}) => {
+  return (
+    <button onClick={onClick}>{content}</button>
+  )
+}
+
+export default Button;

--- a/frontend/src/features/dashboard/job-applications/api/delete-job-application.ts
+++ b/frontend/src/features/dashboard/job-applications/api/delete-job-application.ts
@@ -1,0 +1,8 @@
+import sendRequest from "@/utils/api/send-request";
+
+const BASE_URL = 'api/job-applications';
+
+export function deleteJobApplication(postId: number) {
+  console.log(postId)
+  return sendRequest(`${BASE_URL}/${postId}`, 'DELETE');
+}

--- a/frontend/src/features/dashboard/job-applications/api/delete-job-application.ts
+++ b/frontend/src/features/dashboard/job-applications/api/delete-job-application.ts
@@ -2,7 +2,6 @@ import sendRequest from "@/utils/api/send-request";
 
 const BASE_URL = 'api/job-applications';
 
-export function deleteJobApplication(postId: number) {
-  console.log(postId)
-  return sendRequest(`${BASE_URL}/${postId}`, 'DELETE');
+export function deleteJobApplication(jobApplicationId: number) {
+  return sendRequest(`${BASE_URL}/${jobApplicationId}`, 'DELETE', {jobApplicationId: jobApplicationId});
 }

--- a/frontend/src/features/dashboard/job-applications/components/JobApplicationListTable.test.tsx
+++ b/frontend/src/features/dashboard/job-applications/components/JobApplicationListTable.test.tsx
@@ -10,7 +10,7 @@ describe('JobApplicationListTable', () => {
     ];
 
     beforeEach(() => {
-      render(<JobApplicationListTable jobApplications={mockApplications} />);
+      render(<JobApplicationListTable jobApplications={mockApplications} handleDeleteJobApplication={(id: number) => console.log(id)} />);
     });
 
     it('should render a table with the correct number of rows', () => {
@@ -28,7 +28,7 @@ describe('JobApplicationListTable', () => {
 
   describe('When there are no job applications', () => {
     beforeEach(() => {
-      render(<JobApplicationListTable jobApplications={[]} />);
+      render(<JobApplicationListTable jobApplications={[]} handleDeleteJobApplication={(id: number) => console.log(id)} />);
     });
 
     it('should show an empty state message', () => {

--- a/frontend/src/features/dashboard/job-applications/components/JobApplicationListTable.tsx
+++ b/frontend/src/features/dashboard/job-applications/components/JobApplicationListTable.tsx
@@ -1,28 +1,42 @@
+import Button from '@/components/ui/Buttons/Button';
 import { FC } from 'react';
 import { JobApplication } from 'types/jobApplication';
 
 interface JobApplicationListTableProps {
   jobApplications: JobApplication[];
+  handleDeleteJobApplication: (id: number) => void;
 }
 
 const JobApplicationListTable: FC<JobApplicationListTableProps> = ({
   jobApplications,
+  handleDeleteJobApplication,
 }) => {
   const applicationElements = jobApplications.map((application) => (
     <tr key={application.id}>
-      <td className='border-r-white border-r-[0.5px] border-b-white border-b-[0.5px] p-2'>{application.companyName}</td>
+      <td>
+        <Button
+          content="x"
+          onClick={() => handleDeleteJobApplication(application.id)}
+        />
+      </td>
+      <td className="border-r-white border-r-[0.5px] border-b-white border-b-[0.5px] p-2">
+        {application.companyName}
+      </td>
     </tr>
   ));
 
-  if (!jobApplications.length){
-    return <p>No job applications found.</p>
-  } 
+  if (!jobApplications.length) {
+    return <p>No job applications found.</p>;
+  }
 
   return (
     <table>
       <thead>
         <tr>
-          <th className='border-r-white border-r-[0.5px] border-b-white border-b-[0.5px] p-2'>Company Name</th>
+          <th></th>
+          <th className="border-r-white border-r-[0.5px] border-b-white border-b-[0.5px] p-2">
+            Company Name
+          </th>
         </tr>
       </thead>
       <tbody>{applicationElements}</tbody>


### PR DESCRIPTION
## feat: Enable Job Application Deletion  

### Description  
This PR introduces the ability for users to delete job applications they have created from the dashboard.  

---

### Frontend Changes
- **Delete API Integration**  
  - Implemented a `delete-job-application` API to handle delete requests.  
  - Added a `handleDeleteJobApplication` function in the dashboard page to call this API.  

- **Job Application List Updates**  
  - Added a **delete button** to each job application row in `JobApplicationListTable` to allow users to delete individual applications.  
  - Added an update to the job applications state on the dashboard after deletion.  

- **Testing Improvements**  
  - Updated `JobApplicationListTable` tests to validate the delete functionality.  

---

### Backend Changes  
- **New API Route**  
  - Created a `DELETE /api/job-applications/:id` route that calls the `handleDeleteJobApplication` handler.  

- **Job Application Deletion Logic**  
  - Implemented `handleDeleteJobApplication` to call the `deleteJobApplication` service and handle responses/errors.  
  - Developed `deleteJobApplication` service using Prisma to remove a job application and return the updated list.  

- **Backend Testing**  
  - Added tests for the `deleteJobApplication` service to verify expected behavior.  

---

### UI & Types Updates  
- **Button Component**  
  - Added a reusable `Button` component to be used across the project.  

- **Type Updates**  
  - Updated the `JobApplication` type to enforce `id` as a `number`.  

---

### Next Steps  
- Improve error handling for edge cases and failure scenarios.  
- Expand test coverage as delete functionality evolves.  
- Enhance the `Button` component with styling and variants.  
